### PR TITLE
更改一键复制处的文本错误

### DIFF
--- a/csdn_rewrite.js
+++ b/csdn_rewrite.js
@@ -295,7 +295,8 @@
                     #content_views{ user-select: auto !important; }
                     /* 重写登录后复制按钮样式 | 2021-01-01 10:45:03 */
                     .hljs-button.signin[data-title="登录后复制"] { font-size: 0; }
-                    .hljs-button.signin[data-title="登录后复制"]:before { content: "一键复制"; font-size: 12px; vertical-align: middle; }
+                    /* 不懂 JS，不知道上一行（297）是否需要更改，但测试删除该行后脚本可以正常运行 */
+                    .hljs-button.signin[data-title="登录后复制"]:after { content: "一键复制"; font-size: 12px; vertical-align: middle; }
                     /* 增加隐藏底部推荐文章和版权信息功能 | 2020-11-11 21:03:10 */
                     .recommend-box { display: var(${window.$CSDNCleaner.BackgroundImageRange.recommendBoxDisplayAttributes[0]}) !important; }
                     .blog-footer-bottom { display: var(${window.$CSDNCleaner.BackgroundImageRange.copyrightDisplayAttributes[0]}) !important; }


### PR DESCRIPTION
本人不懂 JS，只是按照自己的想法稍作改动，所以如有错误还请原谅。
原脚本那两行运行的情况下，原本“登陆后复制”的文本不会消失，但是会在前面添加“一键复制”的文本，应该是开发者疏忽了。
所以把 before 改成了 after，这样运行后只有“一键复制”的文本，应该是理想情况吧。